### PR TITLE
Typo resim run get_price.rtm

### DIFF
--- a/full-stack/dapp-toolkit-gumball-machine/README.md
+++ b/full-stack/dapp-toolkit-gumball-machine/README.md
@@ -54,7 +54,7 @@ Store the returned component addres in the component environment variable `expor
 
 Run `resim show $account` and find the admin badge resource address and store it in the admin_badge environment variable `export admin_badge=<resource_address>`
 
-You can run `resim get_price.rtm` to fetch the current gumball price
+You can run `resim run get_price.rtm` to fetch the current gumball price
 
 You can also run the set_price.rtm transaction manifest to change the price of a gumball `resim run set_price.rtm`
 


### PR DESCRIPTION
Incorrect: `resim get_price.rtm`
Correct: `resim run get_price.rtm`